### PR TITLE
Ens from cov

### DIFF
--- a/MY_SRC_pdaf/mod_assimilation_pdaf.F90
+++ b/MY_SRC_pdaf/mod_assimilation_pdaf.F90
@@ -18,7 +18,7 @@ module mod_assimilation_pdaf
        ! (2) read snapshot from separate model files
   integer :: type_central_state = 1    !< Type of central state of ensemble
        !< (0) mean of model snapshots, (1) read from file, (2) use collect_state
-  real(pwp) :: ensscale=1.0            !< Scaling factor for initial ensemble
+  real(pwp) :: ensscale=1.0_pwp        !< Scaling factor for initial ensemble
 
 ! *** Model- and data specific variables ***
 
@@ -157,7 +157,7 @@ module mod_assimilation_pdaf
   INTEGER :: dim_cvec = 0  !< Size of control vector (parameterized part; for subtypes 0,1)
   INTEGER :: dim_cvec_ens = 0   !< Size of control vector (ensemble part; for subtypes 1,2)
   INTEGER :: mcols_cvec_ens = 1 !< Multiplication factor for number of columns for ensemble control vector
-  REAL(pwp) :: beta_3dvar = 0.5 !< Hybrid weight for hybrid 3D-Var
+  REAL(pwp) :: beta_3dvar = 0.5_pwp !< Hybrid weight for hybrid 3D-Var
 !    ! NETF/LNETF
   INTEGER :: type_winf     ! Set weights inflation: (1) activate
   REAL(pwp)    :: limit_winf  ! Limit for weights inflation: N_eff/N>limit_winf
@@ -184,8 +184,6 @@ module mod_assimilation_pdaf
   real(pwp) :: domain_coords(2) !> Coordinates of local analysis domain
 
 ! Constants for coordinate calculations
-  real(8), parameter  :: pi     = 3.14159265358979323846_pwp
-  real :: deg2rad = pi / 180.0_pwp      ! Conversion from degrees to radian
 
 !$OMP THREADPRIVATE(domain_coords, id_lstate_in_pstate)
 
@@ -209,6 +207,8 @@ contains
          only: PDAFomi_assimilate_local, PDAF_get_localfilter
     use mod_parallel_pdaf, &
          only: mype_ens, abort_parallel
+  real(pwp), parameter  :: pi     = 3.14159265358979323846_pwp
+  real(pwp) :: deg2rad = pi / 180.0_pwp      ! Conversion from degrees to radian
       
     integer :: status_pdaf  ! PDAF status flag
     integer :: localfilter  ! Flag for domain-localized filter (1=true)

--- a/MY_SRC_pdaf/mod_aux_pdaf.F90
+++ b/MY_SRC_pdaf/mod_aux_pdaf.F90
@@ -6,6 +6,7 @@ module mod_aux_pdaf
 ! - state transformations (log, etc.)
 
   ! Include dimension information for model grid
+  use mod_kind_pdaf
   use mod_nemo_pdaf, &
        only: nlvls=>jpk, nj_p, ni_p, nwet, wet_pts, use_wet_state
   use mod_statevector_pdaf, &
@@ -25,11 +26,11 @@ contains
     implicit none
 
 ! *** Arguments ***
-    real, intent(in)    :: field(:,:,:,:)   !< Model field
-    real, intent(inout) :: state(:)         !< State vector
+    real(pwp), intent(in)    :: field(:,:,:,:)   !< Model field
+    real(pwp), intent(inout) :: state(:)         !< State vector
     integer, intent(in) :: offset           !< Offset in state vector
     integer, intent(in) :: ndims            !< Number of dimensions in field
-    real, intent(in) :: missval             !< missing value
+    real(pwp), intent(in) :: missval             !< missing value
 
 ! *** Local variables ***
     integer :: i, j, k
@@ -89,10 +90,10 @@ contains
        do k = 1, n_levels
           do j = 1,nj_p
              do i = 1, ni_p
-                if (abs(field(i,j,k,1)- missval) > 0.1) then 
+                if (abs(field(i,j,k,1)- missval) > 0.1_pwp) then 
                    state(cnt) = field(i,j,k,1)
                 else
-                   state(cnt) = 0.0
+                   state(cnt) = 0.0_pwp
                 endif
                 cnt = cnt + 1
              enddo
@@ -111,8 +112,8 @@ contains
     implicit none
 
 ! *** Arguments ***
-    real, intent(in)    :: state(:)         !< State vector
-    real, intent(out)   :: field(:,:,:,:)   !< Model field
+    real(pwp), intent(in)    :: state(:)         !< State vector
+    real(pwp), intent(out)   :: field(:,:,:,:)   !< Model field
     integer, intent(in) :: offset           !< Offset in state vector
     integer, intent(in) :: ndims            !< Number of dimensions in field
 
@@ -192,8 +193,8 @@ contains
 
     integer, intent(in) :: type     !< Direction transformation
     integer, intent(in) :: trafo    !< Type of transformation
-    real, intent(in)    :: shift    !< constant for shifting value in transformation
-    real, intent(inout) :: state(:) !< State vector
+    real(pwp), intent(in)    :: shift    !< constant for shifting value in transformation
+    real(pwp), intent(inout) :: state(:) !< State vector
     integer, intent(in) :: dim      !< dimension of field in state vector
     integer, intent(in) :: off      !< Offset of field in state vector
     character(len=*),intent(in) :: var      !< Name of variable
@@ -249,18 +250,18 @@ contains
 
 ! *** Arguments ***
     integer, intent(in) :: type     !< Direction of transformation
-    real, intent(inout) :: state(:) !< State vector
+    real(pwp), intent(inout) :: state(:) !< State vector
 
 ! *** Local variables ***
-    integer :: i, j       ! Counters
+    integer :: i          ! Counters
     integer :: trafo      ! Type of transformation
-    real    :: shift      ! constant for shifting value in transformation
+    real(pwp)    :: shift      ! constant for shifting value in transformation
     integer :: dim        ! dimension of field in state vector
     integer :: off        ! Offset of field in state vector
     character(len=10) :: var      ! Name of variable
     integer :: dolimit    ! Whether to apply a min/max limit
-    real    :: max_limit  ! Maximum limiting value
-    real    :: min_limit  ! Minimum limiting value
+    real(pwp)    :: max_limit  ! Maximum limiting value
+    real(pwp)    :: min_limit  ! Minimum limiting value
 
 
     do i = 1, n_fields
@@ -334,7 +335,7 @@ contains
     implicit none
 
 ! *** Arguments ***
-    real, intent(inout) :: state(:) !< State vector
+    real(pwp), intent(inout) :: state(:) !< State vector
 
 ! *** Local variables ***
     integer :: i, j       ! Counters
@@ -342,8 +343,8 @@ contains
     integer :: off        ! Offset of field in state vector
     character(len=10) :: var      ! Name of variable
     integer :: dolimit    ! Whether to apply a min/max limit
-    real    :: max_limit  ! Maximum limiting value
-    real    :: min_limit  ! Minimum limiting value
+    real(pwp)    :: max_limit  ! Maximum limiting value
+    real(pwp)    :: min_limit  ! Minimum limiting value
 
 
     do i = 1, n_fields

--- a/MY_SRC_pdaf/mod_io_pdaf.F90
+++ b/MY_SRC_pdaf/mod_io_pdaf.F90
@@ -2,6 +2,7 @@
 !!
 module mod_io_pdaf
 
+  use mod_kind_pdaf
   use mpi
 
   ! Include dimension information for model grid
@@ -17,7 +18,7 @@ module mod_io_pdaf
 
   ! Include parallelization information
   use mod_parallel_pdaf, &
-       only: mype=>mype_ens, npes=>npes_ens, comm_filter
+       only: mype=>mype_ens, npes=>npes_ens, comm_filter, abort_parallel
 
   ! Include auxiliary routines
   use mod_aux_pdaf, &
@@ -41,51 +42,44 @@ module mod_io_pdaf
   character(len=100) :: file_PDAF_incr='incr'         ! File name for increment
   character(len=100) :: file_PDAF_variance='variance' ! File name for ensemble variance
   character(len=200) :: path_inistate      ! Path to NEMO files
-  character(len=8)   :: file_ens_date1     ! Date 1 in NEMO file name
-  character(len=8)   :: file_ens_date2     ! Date 2 in NEMO file name
-  character(len=8)   :: file_inistate_date1     ! Date 1 in NEMO file name
-  character(len=8)   :: file_inistate_date2     ! Date 2 in NEMO file name
   character(len=200) :: path_ens           ! Path of ensemble file  
   character(len=80)  :: file_ens           ! File name of ensemble file
   character(len=200) :: path_restart       ! Path of restart file
   character(len=80)  :: file_restart       ! file name of restart dile
-  character(len=80)  :: ens_datelist       ! Name of file holding dates to read in ensembles states
-  character(len=1)   :: datestype='_'      ! Linking character in dates (`_` or `-`)
+
 
    ! Temporary - from offline code
-  real :: startEnsTime=1.0, endEnsTime=1.0, incrTime=1.0
+  real(pwp) :: startEnsTime=1.0_pwp, endEnsTime=1.0_pwp, incrTime=1.0_pwp
 
   ! NEMO output file
   integer(4)        :: ntimec=1
 
   ! Missing value in netcdf file
-  real(8) :: missing_value
+  real(pwp) :: missing_value
     
 contains
 ! ===================================================================================
 
 !> Read fields from NEMO file into a state vector
 !!
-  subroutine read_state_mv(path, date1, date2, dim_p, itime, coupling, state)
+  subroutine read_state_mv(path, dim_p, itime, coupling, state)
 
     use netcdf
     
     implicit none
     
     character(len = *), intent(in)    :: path          !< Path to file
-    character(len = *), intent(in)    :: date1         !< Start date in file name
-    character(len = *), intent(in)    :: date2         !< End date in file name
     integer(4),         intent(in)    :: dim_p         !< PE-local state dimension
     integer(4),         intent(in)    :: itime         !< Time to read in file
     character(len = *), intent(in)    :: coupling      !< Type of NEMO coupling
-    real(8),            intent(inout) :: state(dim_p)  !< State vector
+    real(pwp),          intent(inout) :: state(dim_p)  !< State vector
     
     ! Local variables 
-    integer(4) :: i, cnt          ! Counters
+    integer(4) :: i               ! Counters
     integer(4) :: varid           ! Variable ID
     integer(4) :: ncid            ! NC file id
     character(len=50) :: filename ! Full file name
-    character(len=17) :: dates    ! String with initial and final date
+
 
     if (verbose>0 .and. mype==0) &
          write(*,'(a,4x,a,i8)') 'NEMO-PDAF', '*** Read model output at time step: ', itime
@@ -93,17 +87,11 @@ contains
     if (.not. allocated(tmp_4d)) allocate(tmp_4d(ni_p, nj_p, nk_p, 1))
 
     ! Initialize state
-    state = 0.0
-
-    if (datestype=='_') then
-       dates = trim(date1)//'_'//trim(date2)
-    else
-       dates = trim(date1)//'-'//trim(date2)
-    end if
+    state = 0.0_pwp
 
     do i = 1, n_fields
     
-       filename = trim(sfields(i)%file)//trim(dates)//trim(sfields(i)%file_post)//'.nc'
+       filename = trim(sfields(i)%file_state)
        if (verbose>1 .and. mype==0) then 
           write(*,'(a,2x,a)') 'NEMO-PDAF', trim(path)//trim(filename)
           write (*,'(a,i5,a,a,a,i10)') &
@@ -117,7 +105,7 @@ contains
        if (coupling/='rest') then
           call check( nf90_get_att(ncid, varid, 'missing_value', missing_value) )
        else
-          missing_value=0.0
+          missing_value=0.0_pwp
        endif
 
        ! Read variable
@@ -157,27 +145,24 @@ contains
 
 !> Read an ensemble of model fields into the ensemble array
 !!  
-  subroutine read_ens_mv_loop(path, date1, date2, dim_p, dim_ens, coupling, ens)
+  subroutine read_ens_mv_loop(path, dim_p, dim_ens, coupling, ens)
 
     use netcdf
     
     implicit none
 
 ! *** Arguments ***    
-    character(len = *), intent(in)   :: path      !< Path of file
-    character(len = *), intent(in)   :: date1     !< Start date in file name
-    character(len = *), intent(in)   :: date2     !< End date in file name
-    integer(4),         intent(in)   :: dim_p     !< State dimension
-    integer(4),         intent(in)   :: dim_ens   !< Ensemble size
-    character(len = *), intent(in)   :: coupling  !< Type of NEMO coupling
-    real(8),            intent(inout):: ens(:,:)  !< Ensemble array
+    character(len = *), intent(in)   :: path                 !< Path of file
+    integer(4),         intent(in)   :: dim_p                !< State dimension
+    integer(4),         intent(in)   :: dim_ens              !< Ensemble size
+    character(len = *), intent(in)   :: coupling             !< Type of NEMO coupling
+    real(pwp),          intent(inout):: ens(dim_p, dim_ens)  !< Ensemble array
     
 ! *** Local variables ***
-    integer(4) :: i, cnt, member   ! Counters
+    integer(4) :: i, member        ! Counters
     integer(4) :: ncid             ! NC file ID
     integer(4) :: varid            ! Variable ID
     character(len=50) :: filename  ! Full file name
-    character(len=17) :: dates     ! Combined date string of file
 
     if (verbose>0 .and. mype==0) &
          write(*,'(a,4x,a)') 'NEMO-PDAF','*** Ensemble: Read model snapshots'
@@ -185,16 +170,11 @@ contains
     if (.not. allocated(tmp_4d)) allocate(tmp_4d(ni_p, nj_p, nk_p, 1))
 
     ! Initialize ensemble
-    ens = 0.0
+    ens = 0.0_pwp
 
     do i = 1, n_fields
 
-       if (datestype=='_') then
-          dates = trim(date1)//'_'//trim(date2)
-       else
-          dates = trim(date1)//'-'//trim(date2)
-       end if
-       filename = trim(sfields(i)%file)//trim(dates)//trim(sfields(i)%file_post)//'.nc'
+       filename = trim(sfields(i)%file)
        if (verbose>1 .and. mype==0) then
           write(*,'(a,2x,a)') 'NEMO-PDAF', trim(path)//trim(filename)
           write (*,'(a,i5,a,a,a,i10)') &
@@ -211,7 +191,7 @@ contains
        if (coupling/='rest') then
           call check( nf90_get_att(ncid, varid, 'missing_value', missing_value) )
        else
-          missing_value=0.0
+          missing_value=0.0_pwp
        endif
 
        do member = 1, dim_ens
@@ -266,7 +246,7 @@ contains
     character(len=*), intent(in)    :: ensfile_fullname        !< Name and path of ensemble file
     integer(4),       intent(in)    :: dim_state               !< PE-local state dimension
     integer(4),       intent(in)    :: dim_ens                 !< Ensemble size
-    real(8),          intent(inout) :: ens(dim_state, dim_ens) !< Ensemble array
+    real(pwp),        intent(inout) :: ens(dim_state, dim_ens) !< Ensemble array
     
     ! Local variables  
     integer(4) :: i                     ! Counter
@@ -326,19 +306,19 @@ contains
           else
              write (*,'(1x,a)') 'ERROR: Ensemble in file is too small'
              write (*,'(1x,a)')  'Stopping program!' 
-             stop 10
+             call abort_parallel()
           end if
 
        else
           write (*,'(1x,a)') 'ERROR: inconsistent state dimension'
           write (*,'(1x,a)')  'Stopping program!' 
-          stop 10
+          call abort_parallel()
        end if
 
     else
        write (*,'(1x,a)') 'ERROR: inconsistent variables in state'
        write (*,'(1x,a)')  'Stopping program!' 
-       stop 10
+       call abort_parallel()
     end if
 
     call check( nf90_close(ncid) )
@@ -350,25 +330,24 @@ contains
 
 !> Initialie ensemble array from a list of NEMO output files
 !!
-  subroutine gen_ens_mv(flate, zeromean, infilelist, inpath, dim_p, dim_ens, ens)
+  subroutine gen_ens_mv(flate, zeromean, inpath, dim_p, dim_ens, ens)
 
   implicit none
   
 ! *** Arguments ***
-  real(8),            intent(in)    :: flate        !< inflation
-  character(len=*),   intent(in)    :: infilelist   !< Name of file holding dates of input files
+  real(pwp),          intent(in)    :: flate        !< inflation
   character(len=*),   intent(in)    :: inpath       !< Path to input files
   integer(4),         intent(in)    :: dim_p        !< State dimension
   integer(4),         intent(in)    :: dim_ens      !< Ensemble size
   logical,            intent(in)    :: zeromean     !< Remove mean value
-  real(8),            intent(inout) :: ens(:, :)    !< Ensemble array
+  real(pwp),          intent(inout) :: ens(:, :)    !< Ensemble array
 
 ! *** Local variables ***
-  integer(4)        :: i, k, iens, ifile  ! Counters
-  integer           :: ios                ! Flag for file reading
-  character(len=8)  :: indate             ! Date string
-  real(8)           :: ens_mean           ! Ensemble mean
-  real(8)           :: invsteps           ! Inverse of ensemble size
+  integer(4)        :: i, k, iens          ! Counters
+  integer           :: ios                 ! Flag for file reading
+  character(len=50) :: filenames(n_fields) ! Filename
+  real(pwp)         :: ens_mean            ! Ensemble mean
+  real(pwp)         :: invsteps            ! Inverse of ensemble size
 
 
 ! *** Read ensemble from files ***
@@ -376,33 +355,39 @@ contains
   if (verbose>0 .and. mype==0) &
        write(*,'(/a,1x,a)') 'NEMO-PDAF', '*** Generating ensemble from output files ***'
 
-  open (unit=10,file=trim(infilelist),iostat=ios)
-  if (ios /= 0) write(*,*) 'Could not open file ',infilelist 
-  
+  do i = 1, n_fields
+    open (unit=10 + i, file=trim(sfields(i)%file), iostat=ios)
+    if (ios /= 0) write(*,*) 'Could not open file ', trim(sfields(i)%file)
+  enddo
+
   iens=0
 
   ensloop: do
 
-     read (10,*,iostat=ios) indate
-     if (ios/=0) exit ensloop
+     do i = 1, n_fields
+        read (10 + i,*,iostat=ios) filenames(i)
+        if (ios/=0) exit ensloop
+     enddo
 
      do k =1, ntimec
         iens = iens + 1
         if (verbose>0 .and. mype==0) write (*,'(a,1x,a,i8)') 'NEMO-PDAF', '--- Read ensemble member', iens
-        call read_ens_mv(inpath, indate, indate, dim_p, k, ens(:,iens))
+        call read_ens_mv(inpath, filenames, dim_p, k, ens(:,iens))
      enddo
 
      if (iens==dim_ens) exit ensloop
 
   enddo ensloop
   
-  close(10)
+  do i = 1, n_fields
+     close(10 + i)
+  enddo
 
   ! Check ensemble size
   if (iens<dim_ens) then
      write (*,'(/1x,a)') 'ERROR: Available files less than ensemble size!'
      write (*,'(1x,a)')  'Stopping program!' 
-     stop 10
+     call abort_parallel()
   end if
 
  
@@ -414,12 +399,12 @@ contains
           write(*,'(a,1x,a)') 'NEMO-PDAF', '--- Subtract mean of ensemble snapshots'
 
 
-     invsteps = 1.0/real(dim_ens)
+     invsteps = 1.0_pwp/real(dim_ens, kind=pwp)
 
 
 !$OMP PARALLEL DO private(k, ens_mean)
      do k=1,dim_p
-        ens_mean = 0.0
+        ens_mean = 0.0_pwp
         do i=1,dim_ens
            ens_mean = ens_mean + invsteps*ens(k,i)
         end do
@@ -439,26 +424,24 @@ end subroutine gen_ens_mv
 
 !> Read a model field into the state vector of an ensemble array
 !!  
-  subroutine read_ens_mv(path, date1, date2, dim_p, itime, state)
+  subroutine read_ens_mv(path, filenames, dim_p, itime, state)
 
     use netcdf
     
     implicit none
 
 ! *** Arguments ***    
-    character(len = *), intent(in)   :: path      !< Path of file
-    character(len = *), intent(in)   :: date1     !< First date in file name
-    character(len = *), intent(in)   :: date2     !< Second date in file name
-    integer(4),         intent(in)   :: dim_p     !< State dimension
-    integer(4),         intent(in)   :: itime     !< Time in file to read
-    real(8),            intent(inout):: state(:)  !< State vector
+    character(len = *), intent(in)   :: path         !< Path of file
+    character(len = *), intent(in)   :: filenames(:) !< filenames of all fields
+    integer(4),         intent(in)   :: dim_p        !< State dimension
+    integer(4),         intent(in)   :: itime        !< Time in file to read
+    real(pwp),          intent(inout):: state(dim_p) !< State vector
     
 ! *** Local variables ***
-    integer(4) :: i, cnt           ! Counters
+    integer(4) :: i                ! Counters
     integer(4) :: ncid             ! NC file ID
     integer(4) :: varid            ! Variable ID
     character(len=50) :: filename  ! Full file name
-    character(len=17) :: dates     ! Combined date string of file
 
     if (verbose>0 .and. mype==0) &
          write(*,'(a,4x,a,i8)') 'NEMO-PDAF','*** Ensemble: Read model output at time step: ', itime
@@ -466,16 +449,11 @@ end subroutine gen_ens_mv
     if (.not. allocated(tmp_4d)) allocate(tmp_4d(ni_p, nj_p, nk_p, 1))
 
     ! Initialize state
-    state = 0.0
+    state = 0.0_pwp
 
     do i = 1, n_fields
 
-       if (datestype=='_') then
-          dates = trim(date1)//'_'//trim(date2)
-       else
-          dates = trim(date1)//'-'//trim(date2)
-       end if
-       filename = trim(sfields(i)%file)//trim(dates)//trim(sfields(i)%file_post)//'.nc'
+       filename = filenames(i)
 
        if (verbose>1 .and. mype==0) then 
           write(*,'(a,2x,a)') 'NEMO-PDAF', trim(path)//trim(filename)
@@ -523,27 +501,129 @@ end subroutine gen_ens_mv
 
 !================================================================================
 
+!> Read initial forecast error covariance from a file
+!!
+  subroutine read_eof_cov(filename_cov, dim_p, rank, state_p, eofV, svals)
+    use mod_nemo_pdaf, only: dim_2d_p, dim_3d_p
+    use mod_statevector_pdaf, only: dim_state
+    use netcdf
+! *** Arguments ***
+    character(*), intent(in) :: filename_cov      !< filename
+    integer, intent(in)      :: dim_p             !< local PE dimension of state vector
+    integer, intent(in)      :: rank              !< rank of the covariance matrix
+    real(pwp), intent(inout) :: eofV(dim_p, rank) !< singular vectors
+    real(pwp), intent(inout) :: svals(rank)       !< singular values
+    real(pwp), intent(inout) :: state_p(dim_p)    !< mean state vector
+
+! *** Local variables ***
+    integer                :: ncid, dimid              ! file and dimension id
+    integer                :: dim_file, rank_file      ! dimension size
+    integer                :: varid                    ! variable id
+    integer                :: i_rank, i_field, i_var   ! counter
+    integer                :: n_rank                   ! last dimension of variables
+    integer                :: offset                   ! domain decomposition offset
+    real(pwp), allocatable :: state_tmp(:, :)             ! local variable
+    real(pwp)              :: missing_value=1.e+20_pwp ! missing value in variables
+    character(len=5)       :: vartypes(2)              ! variable types: svd and mean
+
+    ! *************************************************
+    ! *** Initialize initial state and covar matrix ***
+    ! *************************************************
+    ! initialize the subroutine for reading
+    allocate(state_tmp(dim_3d_p, 1))
+    vartypes = [character(len=5) :: '_svd', '_mean']
+    if (.not. allocated(tmp_4d)) allocate(tmp_4d(ni_p, nj_p, nk_p, 1))
+
+    ! Open nc file
+    WRITE(*, '(9x,a,a)') '--- Reading covariance information from ', TRIM(filename_cov)
+    call check( NF90_OPEN(TRIM(filename_cov), NF90_NOWRITE, ncid) )
+
+    ! Read size of state vector
+    call check( NF90_INQ_DIMID(ncid, 'dim_state', dimid) )
+    call check( NF90_Inquire_dimension(ncid, dimid, len=dim_file) )
+
+    ! Read rank stored in file
+    call check( NF90_INQ_DIMID(ncid, 'rank', dimid) )
+    call check( NF90_Inquire_dimension(ncid, dimid, len=rank_file) )
+
+    ! Check consistency of dimensions
+    checkdim: IF (dim_state == dim_file .AND. rank_file >= rank) THEN
+      ! *** Rank stored in file is smaller than requested EOF rank ***
+      WRITE(*, '(a)') 'Rank stored in file is smaller than requested EOF rank'
+      call check( NF90_CLOSE(ncid) )
+      call abort_parallel()
+    END IF checkdim
+  
+    ! read singular values
+    call check( NF90_INQ_VARID(ncid, 'sigma', varid) )
+    call check( NF90_GET_VAR(ncid, varid, svals, start=[1], count=[rank]) )
+
+    ! Read singular vectors and mean
+    ! position of the domain in the state vector
+    offset = (jstart - 1)*nlons + istart
+    do i_var = 1, 2
+      if (i_var == 1) then
+        n_rank = rank
+      else if (i_var == 2) then
+        n_rank = 1
+      endif
+
+      ! loop over all fields
+      do i_field = 1, n_fields
+        call check( NF90_INQ_VARID(ncid, &
+                    trim(sfields(i_field)%variable)//trim(vartypes(i_var)), &
+                    varid) &
+                   )
+        do i_rank = 1, n_rank
+          ! read and convert state vector into field shape
+          if (sfields(i_field)%ndims == 2) then
+            call check( NF90_GET_VAR(ncid, varid, state_tmp(:dim_2d_p, :), &
+                        start=[offset, i_rank], count=[dim_2d_p, 1]) )
+            tmp_4d(:, :, 1, 1) = reshape(state_tmp(:dim_2d_p, 1), [ni_p, nj_p])
+          else if (sfields(i_field)%ndims == 3) then
+            call check( NF90_GET_VAR(ncid, varid, state_tmp, &
+                                     start=[offset, i_rank], count=[dim_3d_p, 1]) )
+            tmp_4d(:, :, :, 1) = reshape(state_tmp(:, 1), [ni_p, nj_p, nk_p])
+          end if
+
+          if (i_var == 1) then
+            ! convert field into state vector without dry points
+            call field2state(tmp_4d, eofV(:, i_rank), sfields(i_field)%off, &
+                             sfields(i_field)%ndims, missing_value)
+          else if (i_var == 2) then
+            call field2state(tmp_4d, state_p, sfields(i_field)%off, &
+                             sfields(i_field)%ndims, missing_value)
+          endif
+        enddo
+
+      enddo
+
+    enddo
+    call check( NF90_CLOSE(ncid) )
+    deallocate(state_tmp)
+  end subroutine read_eof_cov
+
+
 !> Write an ensemble file holding the state vectors
 !!
-  subroutine write_state_ens(path, file, dim_state, dim_ens, ens)
+  subroutine write_state_ens(file, dim_state, dim_ens, ens)
 
     use netcdf
 
     implicit none 
 
 ! *** Arguments *** 
-    character(len=*), intent(in):: path          !< Path of file
     character(len=*), intent(in):: file          !< File name
     integer(4),       intent(in):: dim_state     !< state dimension
     integer(4),       intent(in):: dim_ens       !< Ensemble size
-    real(8),          intent(in):: ens(:,:)      !< Ensemble array
+    real(pwp),        intent(in):: ens(:,:)      !< Ensemble array
 
 ! *** Local variables *** 
     integer(4) :: i          ! Counter
     integer(4) :: fileid     ! NC file id
     integer(4) :: dimids(2)  ! dimension ids
     integer(4) :: id_ens     ! variable id
-    real(8)    :: fillval    ! fill value
+    real(pwp)  :: fillval    ! fill value
     integer(4) :: startv(2),countv(2)  ! Arrays for writing
     character(len=400) :: varstr   ! String describing variables in state vector
     character(len=200) :: filestr  ! String for file name
@@ -578,7 +658,7 @@ end subroutine gen_ens_mv
 
     ! define variables
     call check( NF90_DEF_VAR(fileid,'ensemble',NF90_DOUBLE,dimids(1:2),id_ens) )
-    fillval = 0.0
+    fillval = 0.0_pwp
     call check( nf90_put_att(fileid, id_ens, "_FillValue", fillval) )
     call check( nf90_put_att(fileid, id_ens, "missing_value", fillval) )
     call check( NF90_def_var_deflate(fileid,id_ens,0,1,1) )
@@ -604,7 +684,7 @@ end subroutine gen_ens_mv
 
 !> Write ensemble as single files holding model fields
 !!
-  subroutine write_ens_files(path,file_ens,dim_state,dim_ens,ens)
+  subroutine write_ens_files(path,file_ens,dim_ens,ens)
 
     use netcdf
 
@@ -613,20 +693,19 @@ end subroutine gen_ens_mv
 ! *** Arguments ***
     character(len=*), intent(in) :: path        !< Path of file
     character(len=*), intent(in) :: file_ens    !< Name stub of file
-    integer(4),       intent(in) :: dim_state   !< State dimension
     integer(4),       intent(in) :: dim_ens     !< Ensemble size
-    real(8),       intent(inout) :: ens(:, :)   !< Ensemble array
+    real(pwp),     intent(inout) :: ens(:, :)   !< Ensemble array
 
 ! *** Local variables ***
     integer(4)          :: i                ! Counter
     character(len=200)  :: file_ensemble   ! Full name of an ensemble size
     character(len=200)  :: titleEns         ! NC title of file
-    real(8)             :: time             ! Time in file
+    real(pwp)           :: time             ! Time in file
 
 
 ! *** Write ensemble perturbation files
 
-    time=10.0 !TO DO: this is random, time has to be read in pdaf.nml and set here
+    time=10.0_pwp !TO DO: this is random, time has to be read in pdaf.nml and set here
 
     titleEns='Ensemble perturbation (ens-mean) for PDAF'
     
@@ -634,7 +713,7 @@ end subroutine gen_ens_mv
 
        file_ensemble=trim(path)//trim(file_ens)//'_'//trim(str(i))//'.nc'
 
-       call write_field_mv(ens(:, i), dim_state, file_ensemble, titleEns,time, 1, 1)
+       call write_field_mv(ens(:, i), file_ensemble, titleEns,time, 1, 1)
     enddo
 
   end subroutine write_ens_files
@@ -643,7 +722,7 @@ end subroutine gen_ens_mv
 
 !> Write a state vector as model fields into a file
 !!
-  subroutine write_field_mv(state, dim, filename, title, &
+  subroutine write_field_mv(state, filename, title, &
        attime, nsteps, step)
     
     use netcdf
@@ -651,26 +730,24 @@ end subroutine gen_ens_mv
     implicit none
 
 ! *** Arguments ***
-    real(8),          intent(inout) :: state(:)  ! State vector
-    integer(4),       intent(in) :: dim          ! State dimension
+    real(pwp),        intent(inout) :: state(:)  ! State vector
     character(len=*), intent(in) :: filename     ! File name
     character(len=*), intent(in) :: title        ! File title
-    real(8),          intent(in) :: attime       ! Time attribute
+    real(pwp),        intent(in) :: attime       ! Time attribute
     integer(4),       intent(in) :: nsteps       ! Number of time steps stored in file
     integer(4),       intent(in) :: step         ! Time index to write at
 
 ! *** Local variables ***
     integer(4) :: ncid
     integer(4) :: dimids_field(4)
-    integer(4) :: cnt,i,j,k
+    integer(4) :: i
     integer(4) :: dimid_time, dimid_lvls, dimid_lat, dimid_lon, dimid_one
     integer(4) :: id_lat, id_lon, id_lev, id_time, id_field
-    integer(4) :: dimids(4)
     integer(4) :: startC(2), countC(2)
     integer(4) :: startt(4), countt(4)
     integer(4) :: startz(1), countz(1)
-    real(8)    :: fillval
-    real(8)    :: timeField(1)
+    real(pwp)  :: fillval
+    real(pwp)  :: timeField(1)
 
     timeField(1)=attime
 
@@ -722,7 +799,7 @@ end subroutine gen_ens_mv
           if (do_deflate) &
                call check( NF90_def_var_deflate(ncid, id_field, 0, 1, 1) )
           call check( nf90_put_att(ncid, id_field, "coordinates", "nav_lat nav_lon") )
-          fillval = 1.0e20
+          fillval = 1.0e20_pwp
           call check( nf90_put_att(ncid, id_field, "_FillValue", fillval) )
           call check( nf90_put_att(ncid, id_field, "missing_value", fillval) )
        end do
@@ -774,7 +851,7 @@ end subroutine gen_ens_mv
     do i = 1, n_fields
 
        ! Convert state vector to field
-       tmp_4d = 1.0e20
+       tmp_4d = 1.0e20_pwp
        call state2field(state, tmp_4d, sfields(i)%off, sfields(i)%ndims)
 
        if (verbose>1 .and. mype==0) &
@@ -815,32 +892,29 @@ end subroutine gen_ens_mv
 
 !> Write increment file
 !!
-  subroutine write_increment(state, dim, filename, id_field)
+  subroutine write_increment(state, filename, id_field)
     
     use netcdf
    
     implicit none
 
 ! *** Arguments ***
-    real(8),       intent(inout) :: state(:)    !< State vector
-    integer(4),       intent(in) :: dim         !< State dimension
+    real(pwp),     intent(inout) :: state(:)    !< State vector
     character(len=*), intent(in) :: filename    !< File name
     integer(4),       intent(in) :: id_field    !< Id of field in stte vector
 
 ! *** Local variables ***
-    integer(4) :: cnt, i, j, k
+    integer(4) :: i
     integer(4) :: ncid
     integer(4) :: dimids_field(4)
     integer(4) :: dimid_time, dimid_lvls, dimid_lat, dimid_lon
     integer(4) :: id_dateb, id_datef
     integer(4) :: id_lat, id_lon, id_lev, id_time, id_incr
-    integer(4) :: dimids(4)
     integer(4) :: startC(2), countC(2)
     integer(4) :: startt(4), countt(4)
     integer(4) :: startz(1), countz(1)
-    real(8)    :: fillval
-    real(8)    :: timeField(1)
-    real(8)    :: bgnTimeInterv(1), finTimeInterv(1), timeInIncr(1)
+    real(pwp)  :: fillval
+    real(pwp)  :: bgnTimeInterv(1), finTimeInterv(1), timeInIncr(1)
 
     ! NOTE: This routine currently only writes a single field from the state vector
     !       which is specified by id_field. this must be a 3D field
@@ -901,7 +975,7 @@ end subroutine gen_ens_mv
        if (do_deflate) &
             call check( NF90_def_var_deflate(ncid, id_incr, 0, 1, 1) )
 
-       fillval = 0.0
+       fillval = 0.0_pwp
        call check( nf90_put_att(ncid, id_incr, "long_name", trim(sfields(id_field)%name_incr)//trim('Increment')) )
        call check( nf90_put_att(ncid, id_incr, "units", trim(sfields(id_field)%unit)) )
        call check( nf90_put_att(ncid, id_incr, "coordinates", "nav_lat nav_lon") )
@@ -940,7 +1014,7 @@ end subroutine gen_ens_mv
     do i = 1, n_fields
 
        ! Convert state vector to field
-       tmp_4d = 0.0
+       tmp_4d = 0.0_pwp
        call state2field(state, tmp_4d, sfields(i)%off, sfields(i)%ndims)
 
        if (verbose>1) &
@@ -977,17 +1051,15 @@ end subroutine gen_ens_mv
 
 !> Overwrite the NEMO restart file
 !!
-  subroutine update_restart_mv(path, file, state, state_tmp)
+  subroutine update_restart_mv(state, state_tmp)
 
     use netcdf
    
     implicit none
 
 ! *** Arguments ***
-    character(len=*), intent(in) :: path         !< Path for restart file
-    character(len=*), intent(in) :: file         !< Restart file name
-    real(8),       intent(inout) :: state(:)     !< State vector
-    real(8),       intent(inout) :: state_tmp(:) !< tmp state vector (used for storage)
+    real(pwp),     intent(inout) :: state(:)     !< State vector
+    real(pwp),     intent(inout) :: state_tmp(:) !< tmp state vector (used for storage)
 
 ! *** Local variables ***
     integer :: i                      ! Counter
@@ -1045,7 +1117,7 @@ end subroutine gen_ens_mv
        ! backwards transformation state - only if not done by write_increment before
 
        ! Convert state vector to field
-       tmp_4d = 0.0
+       tmp_4d = 0.0_pwp
        call state2field(state, tmp_4d, sfields(i)%off, sfields(i)%ndims)
 
        ! *** write variable for current time ***
@@ -1112,7 +1184,7 @@ end subroutine gen_ens_mv
 
     if(status /= nf90_noerr) then 
        print *, trim(nf90_strerror(status))
-       stop "Stopped"
+       call abort_parallel()
     end if
 
   end subroutine check

--- a/MY_SRC_pdaf/mod_nemo_pdaf.F90
+++ b/MY_SRC_pdaf/mod_nemo_pdaf.F90
@@ -8,6 +8,7 @@ module mod_nemo_pdaf
        nimpp, njmpp, tmask, gdept_1d, ndastp
   use par_oce, &
        only: jp_tem, jp_sal
+  use mod_kind_pdaf
 
   ! *** NEMO model variables
 !  integer :: jpiglo, jpjglo, jpk        ! Global NEMO grid dimensions
@@ -20,8 +21,8 @@ module mod_nemo_pdaf
 !  real, allocatable :: gdept_1d(:)      ! Depths
   
   ! *** Other grid variables
-  real, allocatable :: tmp_4d(:,:,:,:)     ! 4D array used to represent full NEMO grid box
-  real, allocatable :: lat1(:), lon1(:)    ! Vectors holding latitude and latitude
+  real(pwp), allocatable :: tmp_4d(:,:,:,:)     ! 4D array used to represent full NEMO grid box
+  real(pwp), allocatable :: lat1(:), lon1(:)    ! Vectors holding latitude and latitude
 
   integer :: dim_2d                        ! Dimension of 2d grid box    
   integer :: nwet                          ! Number of surface wet grid points
@@ -32,13 +33,15 @@ module mod_nemo_pdaf
   integer, allocatable :: idx_nwet(:,:)    ! Index array for wet_pts row index in wet surface grid points
   integer, allocatable :: nlev_wet_2d(:,:) ! Number of wet layers for ij position in 2d box
 
-  integer :: use_wet_state=0
+  integer :: use_wet_state=0               ! 1: State vector contains full columns when surface grid point is wet
+                                           ! 2: State vector only contains wet grid points 
+                                           ! other: State vector contains 2d/3d grid box
 
   integer :: i0, j0                         ! PE-local halo offsets
   integer :: ni_p, nj_p, nk_p               ! Size of decomposed grid
   integer :: istart, jstart                 ! Start indices for internal local domain
   integer :: dim_2d_p, dim_3d_p             ! Dimension of 2d/3d grid box of sub-domain   
-  real, allocatable :: lat1_p(:), lon1_p(:) ! Vectors holding latitude and latitude for decomposition
+  real(pwp), allocatable :: lat1_p(:), lon1_p(:) ! Vectors holding latitude and latitude for decomposition
   integer :: sdim2d, sdim3d                 ! 2D/3D dimension of field in state vector
 
   ! *** File name and path to read grid information

--- a/MY_SRC_pdaf/namelist_cfg.pdaf
+++ b/MY_SRC_pdaf/namelist_cfg.pdaf
@@ -1,0 +1,105 @@
+&tasks_nml
+   tasks = 10
+   screen = 3
+/
+&pdaf_nml
+   screen = 2
+   dim_ens = 10
+   ensscale = 1.0
+/
+&filter_nml
+   filtertype = 5
+   subtype = 0
+   type_trans = 0
+   type_sqrt = 0
+   incremental = 0
+   covartype = 1
+   rank_analysis_enkf = 0
+/
+&infl_nml
+   type_forget = 0
+   forget = 1
+/
+&local_nml
+   lradius = 0
+   locweight = 0
+   sradius = 0
+/
+&obs_nml
+   delt_obs = 496
+/
+&init_nml
+   verbose = 2
+   type_ens_init = 3
+   type_central_state = 0
+
+   path_inistate = './' 
+   path_ens = './'
+   file_ens = 'cov.nc'
+   ! coupling_nemo = 
+/
+&state_vector
+   sv_temp = .true.
+   sv_salt = .true.
+   sv_ssh  = .true.
+   sv_uvel = .true.
+   sv_vvel = .true.
+/
+&sfields_nml
+   sfields(1)%ndims = 2
+   sfields(1)%variable = 'zos'
+   sfields(1)%name_incr = 'bckineta'
+   sfields(1)%name_rest_n = 'sshn'
+   sfields(1)%name_rest_b = 'sshb'
+   sfields(1)%rst_file = 'restart_in.nc'
+   sfields(1)%unit = 'm'
+   ! sfields(1)%file = 'zos.dat'
+   sfields(1)%file = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+   sfields(1)%file_state = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+
+   sfields(2)%ndims = 3
+   sfields(2)%variable = 'thetao'
+   sfields(2)%name_incr = 'bckint'
+   sfields(2)%name_rest_n = 'tn'
+   sfields(2)%name_rest_b = 'tb'
+   sfields(2)%rst_file = 'restart_in.nc'
+   sfields(2)%unit = 'degC'
+   ! sfields(2)%file = 'thetao.dat'
+   sfields(2)%file = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+   sfields(2)%file_state = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+
+   sfields(3)%ndims = 3
+   sfields(3)%variable = 'so'
+   sfields(3)%name_incr = 'bckins'
+   sfields(3)%name_rest_n = 'sn'
+   sfields(3)%name_rest_b = 'sb'
+   sfields(3)%rst_file = 'restart_in.nc'
+   sfields(3)%unit = '1e-3'
+   sfields(3)%limit = 1             ! Apply lower limit
+   sfields(3)%min_limit = 0.0   ! Salinity is never negative
+   ! sfields(3)%file = 'so.dat'
+   sfields(3)%file = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+   sfields(3)%file_state = 'ORCA2_5d_00010101_00011231_grid_T.nc'
+
+   sfields(4)%ndims = 3
+   sfields(4)%variable = 'uo'
+   sfields(4)%name_incr = 'bckinu'
+   sfields(4)%name_rest_n = 'un'
+   sfields(4)%name_rest_b = 'ub'
+   sfields(4)%rst_file = 'restart_in.nc'
+   sfields(4)%unit = 'm/s'
+   ! sfields(4)%file = 'uo.dat'
+   sfields(4)%file = 'ORCA2_5d_00010101_00011231_grid_U.nc'
+   sfields(4)%file_state = 'ORCA2_5d_00010101_00011231_grid_U.nc'
+
+   sfields(5)%ndims = 3
+   sfields(5)%variable = 'vo'
+   sfields(5)%name_incr = 'bckinv'
+   sfields(5)%name_rest_n = 'vn'
+   sfields(5)%name_rest_b = 'vb'
+   sfields(5)%rst_file = 'restart_in.nc'
+   sfields(5)%unit = 'm/s'
+   ! sfields(5)%file = 'vo.dat'
+   sfields(5)%file = 'ORCA2_5d_00010101_00011231_grid_V.nc'
+   sfields(5)%file_state = 'ORCA2_5d_00010101_00011231_grid_V.nc'
+/

--- a/TOOLS/gen_cov/namelist_gen_cov.pdaf
+++ b/TOOLS/gen_cov/namelist_gen_cov.pdaf
@@ -1,25 +1,40 @@
 &n_statevector
-  nfields = 1 ! number of model fields to be read
+  nfields = 5 ! number of model fields to be read
 /
 &state_vector
   ! variable names
   sfields(1)%variable =  'zos'
-  ! sfields(2)%variable =  'thetao'
-  ! sfields(3)%variable =  'so'
-  ! sfields(4)%variable =  'uo'
-  ! sfields(5)%variable =  'vo'
+  sfields(2)%variable =  'thetao'
+  sfields(3)%variable =  'so'
+  sfields(4)%variable =  'uo'
+  sfields(5)%variable =  'vo'
+
+  sfields(1)%nx = 182
+  sfields(2)%nx = 182
+  sfields(3)%nx = 182
+  sfields(4)%nx = 182
+  sfields(5)%nx = 182
+  sfields(1)%ny = 149
+  sfields(2)%ny = 149
+  sfields(3)%ny = 149
+  sfields(4)%ny = 149
+  sfields(5)%ny = 149
+  sfields(1)%nlvls = 1
+  sfields(2)%nlvls = 31
+  sfields(3)%nlvls = 31
+  sfields(4)%nlvls = 31
+  sfields(5)%nlvls = 31
 
   ! input filenames
   ! read from a file list
-  sfields(1)%read_from_list = .true.
-  sfields(1)%file='zos.dat'
-  ! sfields(2)%file='ORCA2_5d_00010101_00011231_grid_T.nc'
-  ! sfields(3)%file='ORCA2_5d_00010101_00011231_grid_T.nc'
-  ! sfields(4)%file='ORCA2_5d_00010101_00011231_grid_U.nc'
-  ! sfields(5)%file='ORCA2_5d_00010101_00011231_grid_V.nc'
+  sfields(1)%file='ORCA2_5d_00010101_00011231_grid_T.nc'
+  sfields(2)%file='ORCA2_5d_00010101_00011231_grid_T.nc'
+  sfields(3)%file='ORCA2_5d_00010101_00011231_grid_T.nc'
+  sfields(4)%file='ORCA2_5d_00010101_00011231_grid_U.nc'
+  sfields(5)%file='ORCA2_5d_00010101_00011231_grid_V.nc'
 /
 &cov_options
-   maxtimes = 30
+   maxtimes = 50
    do_mv = 1
    remove_mean = 0
    limit = 1.0e-12


### PR DESCRIPTION
There are three major changes in the routine:
-  unifying the float-point number precisions
-  separating namelist sections
-  adding the option to generate initial ensemble from covariance matrix
-  bug fixes in tools/gen_cov + specifying the dimension size of each variable in namelist instead of directly from reading netCDF files 